### PR TITLE
Set SHELL variable to bash in Makefile to avoid fallback to sh which …

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 .PHONY: setup test
 setup:
 	rm -rf env


### PR DESCRIPTION
…does not support the command source